### PR TITLE
agent > server_monitor

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,14 +1,14 @@
 if defined?(ChefSpec)
-  def install_newrelic_agent(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:newrelic_agent, :install, resource_name)
+  def install_newrelic_server_monitor(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:newrelic_server_monitor, :install, resource_name)
   end
 
   def install_newrelic_agent_php(resource_name)
     ChefSpec::Matchers::ResourceMatcher.new(:newrelic_agent_php, :install, resource_name)
   end
 
-  def remove_newrelic_agent(resource_name)
-    ChefSpec::Matchers::ResourceMatcher.new(:newrelic_agent, :remove, resource_name)
+  def remove_newrelic_server_monitor(resource_name)
+    ChefSpec::Matchers::ResourceMatcher.new(:newrelic_server_monitor, :remove, resource_name)
   end
 
   def remove_newrelic_agent_php(resource_name)

--- a/providers/server_monitor.rb
+++ b/providers/server_monitor.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: newrelic
-# Provider:: agent
+# Provider:: server_monitor
 #
 # Copyright 2012-2014, Escape Studios
 #

--- a/resources/server_monitor.rb
+++ b/resources/server_monitor.rb
@@ -1,6 +1,6 @@
 #
 # Cookbook Name:: newrelic
-# Resource:: agent
+# Resource:: server_monitor
 #
 # Copyright 2012-2015, Escape Studios
 #

--- a/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/server_monitor.rb
+++ b/test/fixtures/cookbooks/newrelic_lwrp_test/recipes/server_monitor.rb
@@ -1,7 +1,7 @@
 # Encoding: utf-8
 #
 # Cookbook Name:: newrelic_poc
-# Recipe:: agent
+# Recipe:: server_monitor
 #
 # Copyright 2015, Rackspace
 #


### PR DESCRIPTION
Hi,

in the New Relic documentation the server monitor is called "server monitor" as well as "server monitor agent". I'd prefer to keep the "server monitor"-part in the name instead of "agent"...

Thanks in advance for reviewing this PR!

Kind regards,
David